### PR TITLE
ci: add github checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: HTTP Protocol Testing CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up the Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          uv sync
+      - name: Lint with ruff
+        run: |
+          ruff check
+      - name: Type check with mypy
+        run: |
+          mypy .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          uv sync
+      - name: Run unit tests
+        run: |
+          pytest tests/unit/ --cov=. --cov-report=xml
+      - name: Run integration tests
+        run: |
+          pytest tests/integration/ --cov=. --cov-report=xml --cov-append

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
 
       - name: "Lint with ruff"
         run: |
-          uv run ruff check
+          uv run ruff check -v
 
       - name: "Type check with mypy"
         run: |
-          uv run mypy .
+          uv run mypy . -v
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,40 +9,57 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up the Python environment
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.10'
-      - name: Install dependencies
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: "Install dependencies"
         run: |
-          python -m pip install --upgrade pip
-          pip install uv
-          uv --system sync
-      - name: Lint with ruff
+          uv sync --all-extras --dev
+
+      - name: "Lint with ruff"
         run: |
-          ruff check
-      - name: Type check with mypy
+          uv run ruff
+
+      - name: "Type check with mypy"
         run: |
-          mypy .
+          uv run mypy .
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.10'
-      - name: Install dependencies
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: "Install dependencies"
         run: |
-          python -m pip install --upgrade pip
-          pip install uv
-          uv --system sync
-      - name: Run unit tests
+          uv sync --all-extras --dev
+
+      - name: "Run unit tests"
         run: |
-          pytest tests/unit/ --cov=. --cov-report=xml
-      - name: Run integration tests
+          uv run pytest tests/unit/ --cov=. --cov-report=xml
+
+      - name: "Run integration tests"
         run: |
-          pytest tests/integration/ --cov=. --cov-report=xml --cov-append
+          uv run pytest tests/integration/ --cov=. --cov-report=xml --cov-append

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: "Run unit tests"
         run: |
-          uv run pytest tests/unit/ --cov=. --cov-report=xml
+          uv run pytest tests/unit/
 
       - name: "Run integration tests"
         run: |
-          uv run pytest tests/integration/ --cov=. --cov-report=xml --cov-append
+          uv run pytest tests/integration/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: "Lint with ruff"
         run: |
-          uv run ruff
+          uv run ruff check
 
       - name: "Type check with mypy"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv
-          uv sync
+          uv --system sync
       - name: Lint with ruff
         run: |
           ruff check
@@ -39,7 +39,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv
-          uv sync
+          uv --system sync
       - name: Run unit tests
         run: |
           pytest tests/unit/ --cov=. --cov-report=xml


### PR DESCRIPTION
This adds rudimentary github CI checks for linting, type checking, and testing (unit, integration). E2E tests are not included.