### PR TITLE
A handful of fixes

### DIFF
--- a/client.py
+++ b/client.py
@@ -12,13 +12,18 @@ def send_request(
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.connect((host, port))
 
-        response_line = b"HTTP/1.1 200 OK\r\n"
+        request_line = b"GET / HTTP/1.1\r\n"
         headers = b"".join(
-            [b"User-Agent: CrappyClient/0.0.1\r\n", b"Content-Type: text/plain\r\n"]
+            [
+                f"Host: {host}:{port}\r\n".encode("utf-8"),
+                b"User-Agent: CrappyClient/0.0.1\r\n",
+                b"Content-Type: text/plain\r\n",
+                f"Content-Length: {len(request_payload)}\r\n".encode("utf-8"),
+            ]
         )
         blank_line = b"\r\n"
 
-        request = b"".join([response_line, headers, blank_line, request_payload])
+        request = b"".join([request_line, headers, blank_line, request_payload])
         s.sendall(request)
         data = s.recv(1024)
 

--- a/server.py
+++ b/server.py
@@ -8,7 +8,7 @@ NUM_CONNS = 5
 DEFAULT_RESPONSE = b"Request received!"
 
 
-def contruct_response(response_payload: bytes = DEFAULT_RESPONSE) -> bytes:
+def construct_response(response_payload: bytes = DEFAULT_RESPONSE) -> bytes:
     response_line = b"HTTP/1.1 200 OK\r\n"
     headers = b"".join(
         [b"Server: CrappyServer/0.0.1\r\n", b"Content-Type: text/plain\r\n"]
@@ -61,7 +61,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    start_server(response=contruct_response(args.response_payload.encode("utf-8")))
+    start_server(response=construct_response(args.response_payload.encode("utf-8")))
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_client_server.py
+++ b/tests/integration/test_client_server.py
@@ -6,7 +6,7 @@ from typing import Callable, Generator
 import pytest
 
 from client import send_request
-from server import contruct_response, start_server
+from server import construct_response, start_server
 
 # fun with types
 ServerFactoryCallable = Callable[[bytes], tuple[threading.Thread, int]]
@@ -53,7 +53,7 @@ def server_factory() -> ServerFactoryFixture:
         port = random.randint(8081, 9080)
 
         def run_server() -> None:
-            start_server(contruct_response(response_payload), port=port)
+            start_server(construct_response(response_payload), port=port)
 
         thread = threading.Thread(target=run_server, daemon=True)
         threads.append((thread, port))

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -11,7 +11,7 @@ def test_send_request() -> None:
     We pretend-check the client is 'HTTP complicant' by checking it includes the expected headers
     """
     payload = b"test payload"
-    request = b"HTTP/1.1 200 OK\r\nUser-Agent: CrappyClient/0.0.1\r\nContent-Type: text/plain\r\n\r\ntest payload"
+    request = b"GET / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\nUser-Agent: CrappyClient/0.0.1\r\nContent-Type: text/plain\r\nContent-Length: 12\r\n\r\ntest payload"
     response = b"HTTP/1.1 200 OK\r\nServer: CrappyServer/0.0.1\r\nContent-Type: text/plain\r\n\r\nRequest received!"
 
     # mock the server response

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock, patch
 
 import pytest  # noqa: F401
 
-from server import contruct_response, start_server
+from server import construct_response, start_server
 
 
 def test_server_connection() -> None:
@@ -13,7 +13,7 @@ def test_server_connection() -> None:
     host = "127.0.0.1"
     port = 8888
     client_request = b"HTTP/1.1 200 OK\r\nUser-Agent: CrappyClient/0.0.1\r\nContent-Type: text/plain\r\n\r\ntest payload from client"
-    server_response = contruct_response(b"My test response")
+    server_response = construct_response(b"My test response")
 
     mock_conn = Mock()
     mock_socket = Mock()


### PR DESCRIPTION
This fixes a bunch of stuff across the code base:
- incorrect HTTP client request line, was actualyl a bad copy paste of `response_line` from the Server
- a draft of proper readiness check in E2E tests waiting for the Server to start instead of a harcoded sleep
- more precise types for `ServerFactoryCallable`
- made the test case `test_extra_long_request_payload_rejected` less memory hungry
- typos